### PR TITLE
feat: result 패턴 오류 로직 추가

### DIFF
--- a/apps/owner/src/apis/types/index.ts
+++ b/apps/owner/src/apis/types/index.ts
@@ -1,7 +1,7 @@
-export type ResultError = {
+import type { ErrorJson } from "o2o/errors";
+
+export type ResultError = ErrorJson & {
   success: false;
-  errorCode: string;
-  errorMessage: string;
 };
 
 export type ResultSuccess<T> = {

--- a/apps/owner/src/apis/utils/result/index.ts
+++ b/apps/owner/src/apis/utils/result/index.ts
@@ -1,51 +1,48 @@
-import type { Result, ResultError, ResultSuccess } from "@/apis/types";
+import type { Result, ResultSuccess } from "@/apis/types";
 import { HTTPError } from "ky";
+import { CommonErrorCode, type ErrorCode, errorRegistry } from "o2o/errors";
+import type { BaseError } from "o2o/errors/base/BaseError";
 
 export class ApiError extends Error {
-  errorCode: string;
+  errorCode: ErrorCode;
   errorMessage: string;
 
-  constructor(errorCode: string, errorMessage: string) {
+  constructor(errorCode: ErrorCode, errorMessage: string) {
     super(errorMessage);
     this.name = "ApiError";
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }
+}
 
-  toResult(): ResultError {
-    return {
-      success: false,
-      errorCode: this.errorCode,
-      errorMessage: this.errorMessage,
-    };
-  }
+function resolveError(code: ErrorCode): BaseError {
+  const factory = errorRegistry[code] || errorRegistry[CommonErrorCode.UNKNOWN_ERROR];
+  return factory();
+}
+
+function createErrorResult(code: ErrorCode): Result<never> {
+  const error = resolveError(code).toJSON();
+  return {
+    success: false,
+    ...error,
+  };
 }
 
 export const toResult = async <T>(fn: () => Promise<T>): Promise<ResultSuccess<T>> => {
   try {
     const data = await fn();
-    if (data && typeof data === "object" && "success" in data) {
-      // ResultType으로 들어올 때
-      return data as unknown as ResultSuccess<T>;
-    }
-    return {
-      success: true,
-      data,
-    };
+    return { success: true, data };
   } catch (error) {
     if (error instanceof HTTPError) {
       try {
-        const json = await error.response.json<ResultError>();
-        throw new ApiError(json.errorCode, json.errorMessage);
+        const json = await error.response.json();
+        throw resolveError(json.errorCode);
       } catch {
-        throw new ApiError("INVALID_JSON", "에러 응답 파싱 실패");
+        throw resolveError(CommonErrorCode.UNKNOWN_ERROR);
       }
     }
 
-    throw new ApiError(
-      "UNEXPECTED_ERROR",
-      error instanceof Error ? error.message : "알 수 없는 오류입니다.",
-    );
+    throw resolveError(CommonErrorCode.UNKNOWN_ERROR);
   }
 };
 
@@ -53,7 +50,6 @@ export const toSafeResult = async <T>(fn: () => Promise<ResultSuccess<T>>): Prom
   try {
     const data = await fn();
     if (data && typeof data === "object" && "success" in data) {
-      // ResultType으로 들어올 때
       return data as unknown as ResultSuccess<T>;
     }
     return {
@@ -62,17 +58,9 @@ export const toSafeResult = async <T>(fn: () => Promise<ResultSuccess<T>>): Prom
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      return {
-        success: false,
-        errorCode: error.errorCode ?? "UNKNOWN",
-        errorMessage: error.errorMessage ?? "알 수 없는 서버 오류입니다.",
-      };
+      return createErrorResult(error.errorCode);
     }
 
-    return {
-      success: false,
-      errorCode: "UNKNOWN",
-      errorMessage: "알 수 없는 오류입니다.",
-    };
+    return createErrorResult(CommonErrorCode.UNKNOWN_ERROR);
   }
 };

--- a/apps/user/src/apis/types/index.ts
+++ b/apps/user/src/apis/types/index.ts
@@ -1,7 +1,7 @@
-export type ResultError = {
+import type { ErrorJson } from "o2o/errors";
+
+export type ResultError = ErrorJson & {
   success: false;
-  errorCode: string;
-  errorMessage: string;
 };
 
 export type ResultSuccess<T> = {

--- a/apps/user/src/apis/utils/result/index.ts
+++ b/apps/user/src/apis/utils/result/index.ts
@@ -1,51 +1,48 @@
-import type { Result, ResultError, ResultSuccess } from "@/apis/types";
+import type { Result, ResultSuccess } from "@/apis/types";
 import { HTTPError } from "ky";
+import { CommonErrorCode, type ErrorCode, errorRegistry } from "o2o/errors";
+import type { BaseError } from "o2o/errors/base/BaseError";
 
 export class ApiError extends Error {
-  errorCode: string;
+  errorCode: ErrorCode;
   errorMessage: string;
 
-  constructor(errorCode: string, errorMessage: string) {
+  constructor(errorCode: ErrorCode, errorMessage: string) {
     super(errorMessage);
     this.name = "ApiError";
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }
+}
 
-  toResult(): ResultError {
-    return {
-      success: false,
-      errorCode: this.errorCode,
-      errorMessage: this.errorMessage,
-    };
-  }
+function resolveError(code: ErrorCode): BaseError {
+  const factory = errorRegistry[code] || errorRegistry[CommonErrorCode.UNKNOWN_ERROR];
+  return factory();
+}
+
+function createErrorResult(code: ErrorCode): Result<never> {
+  const error = resolveError(code).toJSON();
+  return {
+    success: false,
+    ...error,
+  };
 }
 
 export const toResult = async <T>(fn: () => Promise<T>): Promise<ResultSuccess<T>> => {
   try {
     const data = await fn();
-    if (data && typeof data === "object" && "success" in data) {
-      // ResultType으로 들어올 때
-      return data as unknown as ResultSuccess<T>;
-    }
-    return {
-      success: true,
-      data,
-    };
+    return { success: true, data };
   } catch (error) {
     if (error instanceof HTTPError) {
       try {
-        const json = await error.response.json<ResultError>();
-        throw new ApiError(json.errorCode, json.errorMessage);
+        const json = await error.response.json();
+        throw resolveError(json.errorCode);
       } catch {
-        throw new ApiError("INVALID_JSON", "에러 응답 파싱 실패");
+        throw resolveError(CommonErrorCode.UNKNOWN_ERROR);
       }
     }
 
-    throw new ApiError(
-      "UNEXPECTED_ERROR",
-      error instanceof Error ? error.message : "알 수 없는 오류입니다.",
-    );
+    throw resolveError(CommonErrorCode.UNKNOWN_ERROR);
   }
 };
 
@@ -53,7 +50,6 @@ export const toSafeResult = async <T>(fn: () => Promise<ResultSuccess<T>>): Prom
   try {
     const data = await fn();
     if (data && typeof data === "object" && "success" in data) {
-      // ResultType으로 들어올 때
       return data as unknown as ResultSuccess<T>;
     }
     return {
@@ -62,17 +58,9 @@ export const toSafeResult = async <T>(fn: () => Promise<ResultSuccess<T>>): Prom
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      return {
-        success: false,
-        errorCode: error.errorCode ?? "UNKNOWN",
-        errorMessage: error.errorMessage ?? "알 수 없는 서버 오류입니다.",
-      };
+      return createErrorResult(error.errorCode);
     }
 
-    return {
-      success: false,
-      errorCode: "UNKNOWN",
-      errorMessage: "알 수 없는 오류입니다.",
-    };
+    return createErrorResult(CommonErrorCode.UNKNOWN_ERROR);
   }
 };

--- a/apps/user/src/hooks/api/utils/useMutation/index.ts
+++ b/apps/user/src/hooks/api/utils/useMutation/index.ts
@@ -1,4 +1,4 @@
-import type { ApiError } from "@/apis/utils/result";
+import type { ResultError } from "@/apis/types";
 import {
   type UseMutationOptions,
   type UseMutationResult,
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 export const useMutation = <Data, Variables>(
-  options: UseMutationOptions<Data, ApiError, Variables>,
-): UseMutationResult<Data, ApiError, Variables> => {
+  options: UseMutationOptions<Data, ResultError, Variables>,
+): UseMutationResult<Data, ResultError, Variables> => {
   return useAppMutation(options);
 };

--- a/apps/user/src/hooks/api/utils/useQuery/index.ts
+++ b/apps/user/src/hooks/api/utils/useQuery/index.ts
@@ -1,5 +1,4 @@
-import type { ResultSuccess } from "@/apis/types";
-import type { ApiError } from "@/apis/utils/result";
+import type { ResultError, ResultSuccess } from "@/apis/types";
 import {
   type UseQueryOptions,
   type UseQueryResult,
@@ -7,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 export const useQuery = <Data, QueryKey extends unknown[] = unknown[]>(
-  options: UseQueryOptions<ResultSuccess<Data>, ApiError, ResultSuccess<Data>, QueryKey>,
-): UseQueryResult<ResultSuccess<Data>, ApiError> => {
+  options: UseQueryOptions<ResultSuccess<Data>, ResultError, ResultSuccess<Data>, QueryKey>,
+): UseQueryResult<ResultSuccess<Data>, ResultError> => {
   return useAppQuery(options);
 };

--- a/packages/errors/base/BaseError.ts
+++ b/packages/errors/base/BaseError.ts
@@ -1,3 +1,11 @@
+export interface ErrorJson {
+  name: string;
+  code: string;
+  message: string;
+  statusCode: number;
+  timestamp: Date;
+}
+
 export abstract class BaseError extends Error {
   public readonly code: string;
   public readonly statusCode: number;
@@ -12,7 +20,7 @@ export abstract class BaseError extends Error {
   }
 
   // biome-ignore lint/style/useNamingConvention: <explanation>
-  public toJSON() {
+  public toJSON(): ErrorJson {
     return {
       name: this.name,
       code: this.code,

--- a/packages/errors/common/CommonError.ts
+++ b/packages/errors/common/CommonError.ts
@@ -8,6 +8,8 @@ export enum CommonErrorCode {
   ENTITY_ALREADY_EXISTS = "CEC006",
   VALIDATION_FAILED = "CEC007",
   IMAGE_URL_CONVERSION_FAILED = "CEC008",
+
+  UNKNOWN_ERROR = "CEC999", // 예외 처리되지 않은 오류
 }
 
 export class CommonError extends BaseError {
@@ -19,6 +21,7 @@ export class CommonError extends BaseError {
     [CommonErrorCode.ENTITY_ALREADY_EXISTS]: "엔티티가 이미 존재합니다.",
     [CommonErrorCode.VALIDATION_FAILED]: "유효성 검증에 실패했습니다.",
     [CommonErrorCode.IMAGE_URL_CONVERSION_FAILED]: "이미지 URL 변환에 실패했습니다.",
+    [CommonErrorCode.UNKNOWN_ERROR]: "알 수 없는 오류가 발생했습니다.",
   };
 
   constructor(code: CommonErrorCode, statusCode = 500) {
@@ -51,5 +54,9 @@ export class CommonError extends BaseError {
 
   static imageUrlConversionFailed(): CommonError {
     return new CommonError(CommonErrorCode.IMAGE_URL_CONVERSION_FAILED, 500);
+  }
+
+  static unknownError(): CommonError {
+    return new CommonError(CommonErrorCode.UNKNOWN_ERROR, 500);
   }
 }

--- a/packages/errors/index.ts
+++ b/packages/errors/index.ts
@@ -1,5 +1,5 @@
 // Base Error
-export { BaseError } from "./base/BaseError";
+export { BaseError, type ErrorJson } from "./base/BaseError";
 
 // Common Errors
 export { CommonError, CommonErrorCode } from "./common/CommonError";
@@ -15,6 +15,9 @@ export { StoreError, StoreErrorCode } from "./store/StoreError";
 
 // Customer Errors
 export { CustomerError, CustomerErrorCode } from "./customer/CustomerError";
+
+// Error Registry
+export { default as errorRegistry } from "./utils/errorRegistry";
 
 // Error Types
 import type { CommonError, CommonErrorCode } from "./common/CommonError";

--- a/packages/errors/utils/errorRegistry.ts
+++ b/packages/errors/utils/errorRegistry.ts
@@ -1,0 +1,45 @@
+import { CommonError, CommonErrorCode, CustomerError, CustomerErrorCode } from "..";
+import type { BaseError } from "../base/BaseError";
+import { OrderError, OrderErrorCode } from "../order/OrderError";
+import { PaymentError, PaymentErrorCode } from "../payment/PaymentError";
+import { StoreError, StoreErrorCode } from "../store/StoreError";
+
+type ErrorConstructor = () => BaseError;
+
+const errorRegistry: Record<string, ErrorConstructor> = {
+  [OrderErrorCode.ORDER_NOT_FOUND]: () => OrderError.notFound(),
+  [OrderErrorCode.ORDER_ALREADY_COMPLETED]: () => OrderError.alreadyCompleted(),
+  [OrderErrorCode.ORDER_ALREADY_CANCELLED]: () => OrderError.alreadyCancelled(),
+  [OrderErrorCode.INVALID_ORDER_MENU]: () => OrderError.invalidMenu(),
+  [OrderErrorCode.ORDER_ACCEPT_FAILED]: () => OrderError.acceptFailed(),
+  [OrderErrorCode.ORDER_REJECT_FAILED]: () => OrderError.rejectFailed(),
+  [OrderErrorCode.ORDER_COMPLETE_FAILED]: () => OrderError.completeFailed(),
+  [OrderErrorCode.ORDER_CANCEL_FAILED]: () => OrderError.cancelFailed(),
+  [OrderErrorCode.INVALID_ORDER_STATUS]: () => OrderError.invalidStatus(),
+
+  [PaymentErrorCode.PAYMENT_FAILED]: () => PaymentError.failed(),
+  [PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH]: () => PaymentError.amountMismatch(),
+  [PaymentErrorCode.PAYMENT_ALREADY_PROCESSED]: () => PaymentError.alreadyProcessed(),
+
+  [StoreErrorCode.STORE_CLOSED]: () => StoreError.closed(),
+  [StoreErrorCode.STORE_NOT_FOUND]: () => StoreError.notFound(),
+  [StoreErrorCode.STORE_UNAVAILABLE]: () => StoreError.unavailable(),
+  [StoreErrorCode.SUBSCRIPTION_NOT_FOUND]: () => StoreError.subscriptionNotFound(),
+  [StoreErrorCode.SUBSCRIPTION_UPDATE_FAILED]: () => StoreError.subscriptionUpdateFailed(),
+
+  [CustomerErrorCode.CUSTOMER_NOT_FOUND]: () => CustomerError.customerNotFound(),
+  [CustomerErrorCode.USER_NOT_FOUND]: () => CustomerError.userNotFound(),
+  [CustomerErrorCode.CUSTOMER_ADDRESS_NOT_FOUND]: () => CustomerError.addressNotFound(),
+  [CustomerErrorCode.CUSTOMER_ADDRESS_ALREADY_EXISTS]: () => CustomerError.addressAlreadyExists(),
+
+  [CommonErrorCode.INVALID_INPUT]: () => CommonError.invalidInput(),
+  [CommonErrorCode.ENTITY_NOT_FOUND]: () => CommonError.entityNotFound(),
+  [CommonErrorCode.INTERNAL_SERVER_ERROR]: () => CommonError.internalServerError(),
+  [CommonErrorCode.INVALID_TYPE]: () => CommonError.invalidType(),
+  [CommonErrorCode.ENTITY_ALREADY_EXISTS]: () => CommonError.entityAlreadyExists(),
+  [CommonErrorCode.VALIDATION_FAILED]: () => CommonError.validationFailed(),
+  [CommonErrorCode.IMAGE_URL_CONVERSION_FAILED]: () => CommonError.imageUrlConversionFailed(),
+  [CommonErrorCode.UNKNOWN_ERROR]: () => CommonError.unknownError(),
+};
+
+export default errorRegistry;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

이슈 번호 없음

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

앞서 만들어주신 ErrorCode와 ErrorClass를 사용해서 Result 패턴에 도입한 코드입니다. 

## 🧾 작업 상세 내용

-   [ ] Result 패턴 수정

## 📸 스크린샷 (선택)

| 전  | 후  |
| --- | --- |
|     |     |

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

우선 서버에서 넘겨주는 Error Code로 Error Class가 만들어지기 때문에 한번 Registry를 통해서 처리하는 로직을 만들어봤습니다. 
error가 추가될 떄마다 Registery를 추가하는 불편함이 있는 것 같은데 일단 이런 개념으로 만들면 될 것 같다면 좀 더 작업해볼 예정입니다. 

## 🧪 테스트 방법

## 📚 참고할만한 자료 (선택)
